### PR TITLE
fix: generate migration states on deployment

### DIFF
--- a/lib/deploy.ts
+++ b/lib/deploy.ts
@@ -39,7 +39,10 @@ export async function deployMigrations({
     deployedMigrationNames,
     migrationFileNames
   )
-  const migrationStates = generateMigrationStates(pendingMigrations)
+  const migrationStates = generateMigrationStates(
+    pendingMigrations,
+    options.locale
+  )
 
   await runMigrations(pendingMigrationFilePaths, options)
   await updateMigrationState(options, migrationStates)

--- a/lib/migrationManagement/migrationState.ts
+++ b/lib/migrationManagement/migrationState.ts
@@ -2,7 +2,6 @@ import difference from "lodash/difference"
 
 import { config } from "../config"
 import { LocaleDependent } from "../contentful/types"
-import { MigrationOptions } from "../types"
 
 import {
   getMigrationFilePaths,
@@ -28,13 +27,13 @@ export async function assessPendingMigrations(
 
 export function generateMigrationStates(
   pendingMigrations: string[],
-  options?: MigrationOptions
+  locale?: string
 ) {
-  const locale = options?.locale || config.contentful.defaultLocale
+  const migrationLocale = locale || config.contentful.defaultLocale
 
   return pendingMigrations.map(migrationFile => {
     const fileName: LocaleDependent = {}
-    fileName[locale] = migrationFile
+    fileName[migrationLocale] = migrationFile
 
     return { fileName }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-migrations",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A tool to manage Contentful migrations",
   "files": [
     "bin",


### PR DESCRIPTION
It adds the missing optional locale argument to the migration state generation function.

The deployment wasn't taking into consideration CF locales.