### PR TITLE
Add file path cross OS compatibility with "resolve"  

### DIFF
--- a/lib/migrationManagement/migrationFiles.ts
+++ b/lib/migrationManagement/migrationFiles.ts
@@ -19,25 +19,10 @@ export async function processMigrationFileNames(
 }
 
 async function getMigrationFileNames(migrationsDirectory: string) {
-  const pattern = `${getMigrationsDirectoryPath(
-    migrationsDirectory
-  )}/**/*.{ts,js}`
+  const pattern = `${migrationsDirectory}/**/*.{ts,js}`
   const files = await globby(pattern)
 
   return files.map(file => path.basename(file))
-}
-
-export function getMigrationFilePaths(
-  migrationsDirectory: string,
-  migrationName: string
-) {
-  const directoryPath = getMigrationsDirectoryPath(migrationsDirectory)
-
-  return `${directoryPath}/${migrationName}`
-}
-
-export function getMigrationsDirectoryPath(migrationsDirectory: string) {
-  return path.join(process.cwd(), migrationsDirectory)
 }
 
 export function getNextMigrationFileName(
@@ -55,15 +40,15 @@ export function getNextMigrationFileName(
 }
 
 export function getMigrationFileData(
-  migrationsDir: string,
+  migrationDirectory: string,
   migrationFileName: string,
   useJavascript: boolean
 ) {
   const fileExtension = useJavascript ? "js" : "ts"
-  const path = `${getMigrationsDirectoryPath(
-    migrationsDir
-  )}/${migrationFileName}.${fileExtension}`
+  const migrationPath = path.resolve(
+    `${migrationDirectory}/${migrationFileName}.${fileExtension}`
+  )
   const content = useJavascript ? jsMigrationTemplate : tsMigrationTemplate
 
-  return { content, path }
+  return { content, path: migrationPath }
 }

--- a/lib/migrationManagement/migrationState.ts
+++ b/lib/migrationManagement/migrationState.ts
@@ -1,13 +1,12 @@
+import path from "path"
+
 import difference from "lodash/difference"
 
 import { config } from "../config"
 import { LocaleDependent } from "../contentful/types"
 import { PendingMigration } from "../types"
 
-import {
-  getMigrationFilePaths,
-  processMigrationFileNames,
-} from "./migrationFiles"
+import { processMigrationFileNames } from "./migrationFiles"
 
 export async function assessPendingMigrations(
   migrationsDirectory: string,
@@ -49,6 +48,6 @@ export function getPendingMigrations(
 
   return pendingMigrations.map(fileName => ({
     fileName,
-    filePath: getMigrationFilePaths(migrationsDirectory, fileName),
+    filePath: path.resolve(`${migrationsDirectory}/${fileName}`),
   }))
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-migrations",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A tool to manage Contentful migrations",
   "files": [
     "bin",


### PR DESCRIPTION
We still need to use "resolve" to get the absolute path since it's required by the `contentful-migrations` tool.