### PR TITLE
feat(release-environment): add environment ready status verification

### DIFF
--- a/lib/cli/commands/release.ts
+++ b/lib/cli/commands/release.ts
@@ -17,6 +17,7 @@ type ReleaseArgs = ContentfulCredentialArgs & {
   prefix: string
   availableEnvironments: number
   ignoreMigrationCheck?: boolean
+  environmentCreationSecondsTimeout?: number
 }
 
 export const desc = "Deploy migrations"
@@ -38,6 +39,13 @@ export const builder = (yargs: Argv<{}>) =>
       type: "boolean",
       description: "Ignore pending migration check before deploying",
     })
+    .option("environmentCreationSecondsTimeout", {
+      alias: ["contentful-environment-creation-seconds-timeout"],
+      type: "number",
+      default: 1,
+      description:
+        "Maximum of seconds it should wait for the release environment creation to be ready",
+    })
     .demandOption(["prefix", "availableEnvironments"])
 
 export const handler = async (args: ReleaseArgs) => {
@@ -58,6 +66,7 @@ function getReleaseOptions(args: ReleaseArgs): ReleaseOptions {
     releasePrefix: args.prefix,
     availableEnvironments: args.availableEnvironments,
     ignoreMigrationCheck: args.ignoreMigrationCheck,
+    environmentCreationSecondsTimeout: args.environmentCreationSecondsTimeout,
     options: {
       accessToken: args.token,
       environmentId: args.env,

--- a/lib/createReleaseEnvironment.ts
+++ b/lib/createReleaseEnvironment.ts
@@ -1,4 +1,5 @@
 import {
+  checkEnvironmentReadyStatus,
   createEnvironment,
   getAllEnvironments,
   updateEnvironmentAlias,
@@ -17,6 +18,7 @@ export type ReleaseOptions = {
   releasePrefix: string
   availableEnvironments: number
   ignoreMigrationCheck?: boolean
+  environmentCreationSecondsTimeout?: number
   options: MigrationOptions
 }
 
@@ -24,6 +26,7 @@ export async function createReleaseEnvironment({
   releasePrefix,
   availableEnvironments,
   ignoreMigrationCheck = false,
+  environmentCreationSecondsTimeout = 1,
   options,
 }: ReleaseOptions) {
   if (options.environmentId !== "master") {
@@ -54,6 +57,13 @@ export async function createReleaseEnvironment({
   )
   const releaseEnvironmentId = getNextReleaseEnvId(releasePrefix, environments)
   await createEnvironment({ ...options, environmentId: releaseEnvironmentId })
+  await checkEnvironmentReadyStatus(
+    {
+      ...options,
+      environmentId: releaseEnvironmentId,
+    },
+    environmentCreationSecondsTimeout
+  )
   info(`Environment ${releaseEnvironmentId} was created.`)
   const deployOptions = { ...options, environmentId: releaseEnvironmentId }
   await deployMigrations({ options: deployOptions, deployedMigrations })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-migrations",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A tool to manage Contentful migrations",
   "files": [
     "bin",


### PR DESCRIPTION
Some large environments may need a longer time to be completely copied. Therefore, it's needed to check its "ready" status before proceeding with migration deployments.

### Changes:

- Add `--environmentCreationSecondsTimeout` CLI argument
- Add a function that check if the release environment status is "ready" (i.e. its copy was successful)