### PR TITLE
fix: don't save migrations that were aborted

### DIFF
--- a/lib/contentful/migration.ts
+++ b/lib/contentful/migration.ts
@@ -3,14 +3,24 @@ import { runMigration } from "contentful-migration"
 import { info, success } from "../logger"
 import { MigrationOptions, PendingMigration } from "../types"
 
+export type MigrationResult = { successful: boolean, fileName: string }
+
 export async function runMigrations(
   pendingMigrations: PendingMigration[],
   options: MigrationOptions
-) {
+): Promise<MigrationResult[]> {
   const yes = options.yes !== undefined ? options.yes : true
-  for (const { filePath } of pendingMigrations) {
+  const migrationResult: MigrationResult[] = []
+  for (const { filePath, fileName } of pendingMigrations) {
     info(`Deploying migration ${filePath}...`)
-    await runMigration({ ...options, filePath, yes })
-    success(`${filePath} migration deployed`)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const result = await runMigration({ ...options, filePath, yes })
+    if (result) {
+      success(`${filePath} migration deployed`)
+      migrationResult.push({ successful: true, fileName })
+    }
+    migrationResult.push({ successful: false, fileName })
   }
+
+  return migrationResult
 }

--- a/lib/contentful/migration.ts
+++ b/lib/contentful/migration.ts
@@ -3,7 +3,6 @@ import { runMigration } from "contentful-migration"
 import { info, success } from "../logger"
 import { MigrationOptions, PendingMigration } from "../types"
 
-// eslint-disable-next-line @typescript-eslint/member-delimiter-style
 export type MigrationResult = {
   successful: boolean
   fileName: string
@@ -17,6 +16,8 @@ export async function runMigrations(
   const migrationResult: MigrationResult[] = []
   for (const { filePath, fileName } of pendingMigrations) {
     info(`Deploying migration ${filePath}...`)
+
+    // disable this es-lint warning because the underlying function return "any" type and we have no control over that.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const result = await runMigration({ ...options, filePath, yes })
     if (result) {

--- a/lib/contentful/migration.ts
+++ b/lib/contentful/migration.ts
@@ -3,7 +3,11 @@ import { runMigration } from "contentful-migration"
 import { info, success } from "../logger"
 import { MigrationOptions, PendingMigration } from "../types"
 
-export type MigrationResult = { successful: boolean, fileName: string }
+// eslint-disable-next-line @typescript-eslint/member-delimiter-style
+export type MigrationResult = {
+  successful: boolean
+  fileName: string
+}
 
 export async function runMigrations(
   pendingMigrations: PendingMigration[],

--- a/lib/contentful/migration.ts
+++ b/lib/contentful/migration.ts
@@ -23,8 +23,9 @@ export async function runMigrations(
     if (result) {
       success(`${filePath} migration deployed`)
       migrationResult.push({ successful: true, fileName })
+    } else {
+      migrationResult.push({ successful: false, fileName })
     }
-    migrationResult.push({ successful: false, fileName })
   }
 
   return migrationResult

--- a/lib/deploy.ts
+++ b/lib/deploy.ts
@@ -44,12 +44,13 @@ export async function deployMigrations({
     return pendingMigrations
   }
 
+  const runMigrationsResult = await runMigrations(pendingMigrations, options)
   const migrationStates = generateMigrationStates(
     pendingMigrations.map(({ fileName }) => fileName),
+    runMigrationsResult,
     options.locale
   )
 
-  await runMigrations(pendingMigrations, options)
   await updateMigrationState(options, migrationStates)
 
   return pendingMigrations

--- a/lib/migrationManagement/migrationState.ts
+++ b/lib/migrationManagement/migrationState.ts
@@ -8,6 +8,8 @@ import { PendingMigration } from "../types"
 
 import { processMigrationFileNames } from "./migrationFiles"
 
+import { MigrationResult } from "lib/contentful/migration"
+
 export async function assessPendingMigrations(
   migrationsDirectory: string,
   deployedMigrations: string[]
@@ -27,16 +29,23 @@ export async function assessPendingMigrations(
 
 export function generateMigrationStates(
   pendingMigrations: string[],
+  runMigrationsResult: MigrationResult[],
   locale?: string
 ) {
   const migrationLocale = locale || config.contentful.defaultLocale
 
-  return pendingMigrations.map(migrationFile => {
-    const fileName: LocaleDependent = {}
-    fileName[migrationLocale] = migrationFile
+  return pendingMigrations
+    .filter(
+      migrationFile =>
+        runMigrationsResult.find(result => result?.fileName === migrationFile)
+          ?.successful
+    )
+    .map(migrationFile => {
+      const fileName: LocaleDependent = {}
+      fileName[migrationLocale] = migrationFile
 
-    return { fileName }
-  })
+      return { fileName }
+    })
 }
 
 export function getPendingMigrations(

--- a/test/migrationManagement/__snapshots__/migrationState.test.ts.snap
+++ b/test/migrationManagement/__snapshots__/migrationState.test.ts.snap
@@ -12,5 +12,10 @@ Array [
       "en-US": "0002-migration",
     },
   },
+  Object {
+    "fileName": Object {
+      "en-US": "0004-migration",
+    },
+  },
 ]
 `;

--- a/test/migrationManagement/migrationState.test.ts
+++ b/test/migrationManagement/migrationState.test.ts
@@ -6,10 +6,17 @@ import { config } from "../config"
 
 describe("Migration State", () => {
   it("generates a valid migration state update based on the pending migrations", () => {
-    const pendingMigrations = ["0001-migration", "0002-migration"]
+    const pendingMigrations = [
+      "0001-migration",
+      "0002-migration",
+      "0003-migration",
+      "0004-migration",
+    ]
     const runMigrationsResult = [
       { successful: true, fileName: pendingMigrations[0] },
       { successful: true, fileName: pendingMigrations[1] },
+      { successful: false, fileName: pendingMigrations[2] },
+      { successful: true, fileName: pendingMigrations[3] },
     ]
     const migrationStateUpdatePayload = generateMigrationStates(
       pendingMigrations,

--- a/test/migrationManagement/migrationState.test.ts
+++ b/test/migrationManagement/migrationState.test.ts
@@ -7,8 +7,14 @@ import { config } from "../config"
 describe("Migration State", () => {
   it("generates a valid migration state update based on the pending migrations", () => {
     const pendingMigrations = ["0001-migration", "0002-migration"]
-    const migrationStateUpdatePayload =
-      generateMigrationStates(pendingMigrations)
+    const runMigrationsResult = [
+      { successful: true, fileName: pendingMigrations[0] },
+      { successful: true, fileName: pendingMigrations[1] },
+    ]
+    const migrationStateUpdatePayload = generateMigrationStates(
+      pendingMigrations,
+      runMigrationsResult
+    )
 
     expect(migrationStateUpdatePayload).toMatchSnapshot()
   })


### PR DESCRIPTION
## Description

It's possible to run the migration commands and specify a `--yes ` that when the migration is aborted, our tool still saves an entry on contentful as if the migration was applied.

## Proposed Changes

The changes in the PR will only save cf-migrations content that was applied.

## How to test

You can test using the https://github.com/foobaragency/cf-migration-example

1. Set up the example app and run the deploy command for a single file. You need to specify the flag `-y false` and select `n` when prompted to skip the migration. Check contentful dashboard and you'll see the entry was saved for the aborted migration.
2. Clone this PR, run the `build` command, then link the local build to the sample app you used in step 1. Now that they're linked, you should be able to use the local build instead of the one installed via npm. 
3. Run the deploy command with the `-y false` flag and enter `n` when prompted if you want to apply migrations. Check if the entry for the aborted migration was applied. 