### PR TITLE
Update commitlint rule and update release GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,4 @@
-module.exports = { extends: ["@commitlint/config-conventional"] }
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: { "body-max-line-length": [0, "always"] },
+}


### PR DESCRIPTION
# commitlint change

The body-max-line-length prevents causes problems for the `release` GitHub actions because it generates a long body description sometimes. This change disables that rule, so we can have a longer descriptive message.

# release github actions

Publish commits to master to npm