### PR TITLE
fix: upgraded contentful-migration 4.0.14 => 4.5.0

### DIFF
--- a/lib/migrationManagement/migrationFiles.ts
+++ b/lib/migrationManagement/migrationFiles.ts
@@ -2,7 +2,7 @@ import path from "path"
 
 import last from "lodash/last"
 import { paramCase } from "change-case"
-import globby from "globby"
+import { globby } from "globby"
 
 import { getMigrationDetailsAndValidate } from "./migrationValidations"
 import { jsMigrationTemplate, tsMigrationTemplate } from "./fileTemplates"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "chalk": "^4.1.0",
     "change-case": "^4.1.2",
     "contentful-management": "^7.14.0",
-    "contentful-migration": "^4.0.14",
+    "contentful-migration": "^4.5.0",
     "dotenv": "^10.0.0",
     "fs-extra": "^10.0.0",
     "globby": "^12.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,7 +2291,7 @@ contentful-management@^7.14.0, contentful-management@^7.32.1:
     lodash.isplainobject "^4.0.6"
     type-fest "^0.20.2"
 
-contentful-migration@^4.0.14:
+contentful-migration@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/contentful-migration/-/contentful-migration-4.5.0.tgz#7c5ea14ca6e0646c57cc05b86efc569633b93f4c"
   integrity sha512-5TitCU57jXeFkPDSX88pvAypT386c3Keoz4p3IxGzh5Y7fkKt2NB2rotfd2Gs7S4rK17wirojXwhV9WlfbMp6A==


### PR DESCRIPTION
**Upgraded contentful-migration package from 4.0.14 to 4.5.0.**

>  contentful-migration 4.5.0 now have an option to add default value while creating a field.

- There is a [commit](https://github.com/foobaragency/cf-migrations/commit/b183bfec9338951c4669da877e8625be161eca54) in which contentful-migration package was upgraded to 4.5.0 but the update was not added to package.json so I created this PR to upgrade this package in package.json as well.
- Updated the globby import.
