### PR TITLE
Save deployed migrations even if some had errors

### DIFF
--- a/docs/generated/CHANGELOG.md
+++ b/docs/generated/CHANGELOG.md
@@ -1,14 +1,12 @@
 # [1.2.0](https://github.com/foobaragency/cf-migrations/compare/v1.1.3...v1.2.0) (2021-09-07)
 
-
 ### Bug Fixes
 
-* executed prettier to fix CHANGELOG.md file ([d07defe](https://github.com/foobaragency/cf-migrations/commit/d07defe09b255efacc8e6f1e5a30153c3885a0a7))
-
+- executed prettier to fix CHANGELOG.md file ([d07defe](https://github.com/foobaragency/cf-migrations/commit/d07defe09b255efacc8e6f1e5a30153c3885a0a7))
 
 ### Features
 
-* change to use fast-glob instead of globby ([09919e8](https://github.com/foobaragency/cf-migrations/commit/09919e85bc8461fc12ade0778acef931267a8013))
+- change to use fast-glob instead of globby ([09919e8](https://github.com/foobaragency/cf-migrations/commit/09919e85bc8461fc12ade0778acef931267a8013))
 
 ## [1.1.3](https://github.com/foobaragency/cf-migrations/compare/v1.1.2...v1.1.3) (2021-09-03)
 

--- a/lib/contentful/migration.ts
+++ b/lib/contentful/migration.ts
@@ -1,6 +1,6 @@
 import { runMigration } from "contentful-migration"
 
-import { info, success } from "../logger"
+import { info, success, error } from "../logger"
 import { MigrationOptions, PendingMigration } from "../types"
 
 export type MigrationResult = {
@@ -17,9 +17,16 @@ export async function runMigrations(
   for (const { filePath, fileName } of pendingMigrations) {
     info(`Deploying migration ${filePath}...`)
 
-    // disable this es-lint warning because the underlying function return "any" type and we have no control over that.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const result = await runMigration({ ...options, filePath, yes })
+    let result
+    try {
+      // disable this es-lint warning because the underlying function return "any" type and we have no control over that.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      result = await runMigration({ ...options, filePath, yes })
+    } catch (e) {
+      info(`${filePath} migration failed`)
+      error((e as Error).message)
+    }
+
     if (result) {
       success(`${filePath} migration deployed`)
       migrationResult.push({ successful: true, fileName })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,14 +1279,6 @@
     "@typescript-eslint/typescript-estree" "4.31.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.30.0":
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz#1a3ffbb385b1a06be85cd5165a22324f069a85ee"
-  integrity sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==
-  dependencies:
-    "@typescript-eslint/types" "4.30.0"
-    "@typescript-eslint/visitor-keys" "4.30.0"
-
 "@typescript-eslint/scope-manager@4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz#9be33aed4e9901db753803ba233b70d79a87fc3e"
@@ -1295,28 +1287,10 @@
     "@typescript-eslint/types" "4.31.0"
     "@typescript-eslint/visitor-keys" "4.31.0"
 
-"@typescript-eslint/types@4.30.0":
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.30.0.tgz#fb9d9b0358426f18687fba82eb0b0f869780204f"
-  integrity sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==
-
 "@typescript-eslint/types@4.31.0":
   version "4.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.0.tgz#9a7c86fcc1620189567dc4e46cad7efa07ee8dce"
   integrity sha512-9XR5q9mk7DCXgXLS7REIVs+BaAswfdHhx91XqlJklmqWpTALGjygWVIb/UnLh4NWhfwhR5wNe1yTyCInxVhLqQ==
-
-"@typescript-eslint/typescript-estree@4.30.0":
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz#ae57833da72a753f4846cd3053758c771670c2ac"
-  integrity sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==
-  dependencies:
-    "@typescript-eslint/types" "4.30.0"
-    "@typescript-eslint/visitor-keys" "4.30.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.31.0":
   version "4.31.0"
@@ -1330,14 +1304,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.30.0":
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz#a47c6272fc71b0c627d1691f68eaecf4ad71445e"
-  integrity sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==
-  dependencies:
-    "@typescript-eslint/types" "4.30.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.31.0":
   version "4.31.0"


### PR DESCRIPTION
When deploying multiple migrations, and one of them fails, the deployed migrations are not saved. 

This change saves the deployed migrations so that the script doesn't try to apply deployed migrations again.

### How to test?

You can test with [cf-migration-example](https://github.com/foobaragency/cf-migration-example)

1. Clone the repo and use `yarn link` to link to a repo you want to test with. 
2. Have two migrations where you expect one to succeed and the other to fail. 
3. Deploy the migration and check that the deployed one is saved in Contentful, and you see an error message in the console for the failed migration. 