### PR TITLE
fix: paginate getMigrationEntries to get all migration entries

### DIFF
--- a/lib/contentful/management.ts
+++ b/lib/contentful/management.ts
@@ -1,4 +1,4 @@
-import { CollectionProp, EntryProps } from "contentful-management/types"
+import { EntryProps } from "contentful-management/types"
 
 import { config } from "../config"
 import { ContentfulPartialOptions } from "../types"
@@ -26,11 +26,11 @@ export async function getDeployedMigrations(options: ContentfulPartialOptions) {
 }
 
 export function getDeployedMigrationNames(
-  migrationEntries: CollectionProp<EntryProps>,
+  migrationEntries: EntryProps[],
   contentfulLocale?: string
 ) {
   const locale = contentfulLocale || config.contentful.defaultLocale
-  const deployedFiles = migrationEntries.items.map(
+  const deployedFiles = migrationEntries.map(
     item => (item.fields as MigrationEntry).fileName[locale]
   )
 

--- a/test/contentful/management.test.ts
+++ b/test/contentful/management.test.ts
@@ -1,25 +1,49 @@
-import { CollectionProp } from "contentful-management/dist/typings/common-types"
-import { EntryProps } from "contentful-management/dist/typings/export-types"
+import { EntryProps } from "contentful-management/types"
 
 import { getDeployedMigrationNames } from "../../lib/contentful/management"
 
 describe("Contentful Management", () => {
-  const migrationEntries = {
-    items: [
-      {
-        fields: { fileName: { "en-US": "0004-migration.ts" } },
+  const sys = {
+    space: {
+      sys: {
+        type: "Link",
+        linkType: "Space",
+        id: "rklm4ep5nhjl",
       },
-      {
-        fields: { fileName: { "en-US": "0003-migration.ts" } },
+    },
+    id: "ZR86DUHQcB7GQNGB9AIjt",
+    type: "Asset",
+    createdAt: "2020-10-26T11:17:35.480Z",
+    updatedAt: "2020-10-26T11:17:35.480Z",
+    environment: {
+      sys: {
+        id: "dev",
+        type: "Link",
+        linkType: "Environment",
       },
-      {
-        fields: { fileName: { "en-US": "0002-migration.ts" } },
-      },
-      {
-        fields: { fileName: { "en-US": "0001-migration.ts" } },
-      },
-    ],
-  } as unknown as CollectionProp<EntryProps>
+    },
+    version: 1,
+    contentType: { sys: { type: "", linkType: "", id: "" } },
+  }
+
+  const migrationEntries: EntryProps[] = [
+    {
+      fields: { fileName: { "en-US": "0004-migration.ts" } },
+      sys,
+    },
+    {
+      fields: { fileName: { "en-US": "0003-migration.ts" } },
+      sys,
+    },
+    {
+      fields: { fileName: { "en-US": "0002-migration.ts" } },
+      sys,
+    },
+    {
+      fields: { fileName: { "en-US": "0001-migration.ts" } },
+      sys,
+    },
+  ]
 
   it("extracts deployed migration names from the Migration entries", () => {
     const deployedMigrations = getDeployedMigrationNames(migrationEntries)


### PR DESCRIPTION
This fixes https://github.com/foobaragency/cf-migrations/pull/200. I can't push a new fix because it's in Adrian's personal repo.