### PR TITLE
Switch to ESM

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  extends: ["@commitlint/config-conventional"],
-  rules: { "body-max-line-length": [0, "always"] },
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: "ts-jest",
   testEnvironment: "node",
   clearMocks: true,

--- a/lib/migrations/0001-create-migration-type.ts
+++ b/lib/migrations/0001-create-migration-type.ts
@@ -1,10 +1,10 @@
-import { MigrationFunction } from "contentful-migration"
+import Migration, { MigrationFunction } from "contentful-migration"
 
 import { config } from "../config"
 
 const { id, name } = config.contentful.contentType
 
-export = function (migration) {
+function up(migration: Migration) {
   const fooType = migration.createContentType(id, {
     name,
     description: "Migrations deployed in this environment",
@@ -16,4 +16,6 @@ export = function (migration) {
     .name("File Name")
     .type("Symbol")
     .required(true)
-} as MigrationFunction
+}
+
+export default up as MigrationFunction

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cf-migrations",
   "version": "0.0.0-semantically-released",
   "description": "A tool to manage Contentful migrations",
+  "type": "module",
   "files": [
     "bin",
     "lib",
@@ -24,6 +25,17 @@
     "migrations",
     "management"
   ],
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ],
+    "rules": {
+      "body-max-line-length": [
+        0,
+        "always"
+      ]
+    }
+  },
   "scripts": {
     "build": "ttsc --project tsconfig.lib.json",
     "generate:apidocs": "bash scripts/generate-api-docs.sh",
@@ -50,6 +62,7 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^27.0.1",
     "@types/lodash": "^4.14.168",
+    "@types/yargs": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "cz-conventional-changelog": "3.3.0",
@@ -69,7 +82,7 @@
     "ttypescript": "^1.5.12",
     "typedoc": "^0.22.3",
     "typedoc-plugin-markdown": "^3.7.1",
-    "typescript": "^4.2.4",
+    "typescript": "4.4.4",
     "typescript-transform-paths": "^3.0.0"
   },
   "dependencies": {

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -12,7 +12,7 @@
     "lib": ["es2019"],
     "moduleResolution": "node",
     "strict": true,
-    "module": "commonjs",
+    "module": "es2015",
     "target": "es2019",
     "strictNullChecks": true,
     "noImplicitThis": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,6 +1388,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^17.0.4":
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.4.tgz#d7ad5c311aaca3d7daebba169e1ecf35be97ceee"
+  integrity sha512-D/wihO9WFYqwsmJI0e0qS+U09wIQtYRSBJlXWjTFGjouEuOCy0BU4N/ZK5utb00S5lW/9LO7vOpvGDd8M06NvQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.0.0.tgz#ecc7cc69d1e6f342beb6ea9cf9fbc02c97a212ac"
@@ -7371,7 +7378,7 @@ typescript-transform-paths@^3.0.0:
   dependencies:
     minimatch "^3.0.4"
 
-typescript@^4.2.4, typescript@^4.4.3:
+typescript@4.4.4, typescript@^4.4.3:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==


### PR DESCRIPTION
Node.js supports ES modules since version 12 and many libraries are moving to ESM. TypeScript 4.5 will have native support for ESM as well. 

I suggest we move to using ESM for this package as well. But you can also make the argument of supporting CJS and ESM at the same time. I would say we go Pure ESM. These are my reasons:

## Why USE Pure ESM Now?

- Native TypeScript Support (v4.5)
- Native Next.js support being worked on (should be in the next version)
- Node 12 already supports this natively

## Why Dual CJS/ESM?

- Supports all both CJS and ESM users but with increased package bundle size.

## Why not Dual modules?

A lot of published dual ESM/CJS packages cause the [dual package hazard](https://nodejs.org/api/packages.html#packages_dual_package_hazard). To avoid the dual package hazard, all the package's modules must be CJS with a single "default export" (module.exports =), with the exception of index files that are conditionally resolved for ESM consumers (via conditional exports) to allow proper named exports. To read more about this downside, read [this](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#gistcomment-3850849).

For instance, the yargs package we use in this repo doesn't have support for some of its APIs in ESM. I think it's hard to maintain this kind of pattern and I would rather stick to one or the other (i.e CJS or ESM)

---
Known Issues in this PR:

- Yargs doesn't work well with ESM based on our current usage. I got stuck trying to tweak it. I am considering swapping it for something else e.g https://github.com/tj/commander.js. But there are many good ones as well. 

TODO:

- [ ] Switch to TypeScript 4.5
- [ ] Switch to ESM
- [ ] Confirm test and package runs as usual. Or document breaking changes.
- [ ] Publish a beta version to verify it works well in other projects.


Feel free to leave opinions and suggestions

**Important!** Publish beta version before merging to master