### PR TITLE
feat: copy scheduledActions from previous release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ npx cf-migrations release
 
 Since the number of available environments is limited, the oldest release that is not aliased will be removed.
 
+> 📢 Since contentful does not have a functionality yet to also copy the scheduled actions if you create a new environment from an existing one,
+> we have created a feature as a workaround to do the job.
+> The feature is by default activated and can be deactivated by setting the parameter `copy-scheduled-actions` to `false`.
+
 ## 📚 API
 
 Using `cf-migrations`' CLI isn't the only option: you can integrate its functionalities with your project by using the library's API.

--- a/docs/generated/CHANGELOG.md
+++ b/docs/generated/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [1.2.4](https://github.com/foobaragency/cf-migrations/compare/v1.2.3...v1.2.4) (2021-12-14)
 
-
 ### Bug Fixes
 
-* **lint:** changelog format ([c008248](https://github.com/foobaragency/cf-migrations/commit/c0082482a3c55675be570ea1cfcdaf97782e45a6))
+- **lint:** changelog format ([c008248](https://github.com/foobaragency/cf-migrations/commit/c0082482a3c55675be570ea1cfcdaf97782e45a6))
 
 ## [1.2.3](https://github.com/foobaragency/cf-migrations/compare/v1.2.2...v1.2.3) (2021-10-14)
 

--- a/lib/cli/commands/release.ts
+++ b/lib/cli/commands/release.ts
@@ -18,6 +18,8 @@ type ReleaseArgs = ContentfulCredentialArgs & {
   availableEnvironments: number
   ignoreMigrationCheck?: boolean
   environmentCreationSecondsTimeout?: number
+  copyScheduledActions: boolean
+  rateLimit: number
 }
 
 export const desc = "Deploy migrations"
@@ -46,6 +48,19 @@ export const builder = (yargs: Argv<{}>) =>
       description:
         "Maximum of seconds it should wait for the release environment creation to be ready",
     })
+    .option("copyScheduledActions", {
+      alias: ["copy-scheduled-actions"],
+      type: "boolean",
+      default: true,
+      description:
+        "Copy scheduled actions from previous release to new release",
+    })
+    .option("rateLimit", {
+      alias: ["contentful-api-calls-per-second", "rl"],
+      type: "number",
+      default: 7,
+      description: "Rate limit of api calls per second",
+    })
     .demandOption(["prefix", "availableEnvironments"])
 
 export const handler = async (args: ReleaseArgs) => {
@@ -67,6 +82,8 @@ function getReleaseOptions(args: ReleaseArgs): ReleaseOptions {
     availableEnvironments: args.availableEnvironments,
     ignoreMigrationCheck: args.ignoreMigrationCheck,
     environmentCreationSecondsTimeout: args.environmentCreationSecondsTimeout,
+    copyScheduledActions: args.copyScheduledActions,
+    rateLimit: args.rateLimit,
     options: {
       accessToken: args.token,
       environmentId: args.env,

--- a/lib/contentful/release.ts
+++ b/lib/contentful/release.ts
@@ -32,6 +32,26 @@ export function getOldestUnaliasedReleaseEnvironment(
 }
 
 /**
+ * get currently active release that is aliased with aliasedEnvironment
+ */
+export function getActiveReleaseEnvId(
+  releasePrefix: string,
+  aliasedEnvironment: string,
+  environments: EnvironmentProps[]
+) {
+  const activeRelease = getReleaseEnvironmentsOldestFirst(
+    releasePrefix,
+    environments
+  )
+    .filter(
+      env => !!env.sys.aliasedEnvironment && env.sys.id === aliasedEnvironment
+    )
+    .pop()
+
+  return activeRelease?.name
+}
+
+/**
  * Create a fresh copy of the target environment for the new release.
  */
 export function getNextReleaseEnvId(

--- a/lib/contentful/scheduledActions.ts
+++ b/lib/contentful/scheduledActions.ts
@@ -1,0 +1,237 @@
+import { CursorPaginatedCollectionProp } from "contentful-management/dist/typings/common-types"
+import { ScheduledActionProps } from "contentful-management"
+import { CreateUpdateScheduledActionProps } from "contentful-management/dist/typings/entities/scheduled-action"
+import chunk from "lodash/chunk"
+
+import { info, warn } from "../logger"
+
+import { getClient } from "./client"
+
+import { ContentfulPartialOptions } from "lib/types"
+
+export async function getScheduledActionsFromEnvironment(
+  options: ContentfulPartialOptions,
+  environment: string
+): Promise<ScheduledActionProps[]> {
+  const { spaceId } = options
+
+  const result: ScheduledActionProps[] = []
+  const client = getClient(options)
+  let pageNext
+  let index = 0
+
+  const query = {
+    "environment.sys.id": environment,
+    "sys.status": "scheduled",
+    limit: 100,
+  }
+
+  do {
+    const response: CursorPaginatedCollectionProp<ScheduledActionProps> =
+      await client.scheduledActions.getMany({
+        spaceId,
+        query: {
+          ...query,
+          ...(pageNext ? { pageNext } : {}),
+        },
+      })
+
+    // add items to result
+    result.push(...response.items)
+
+    // update pageNext token with value from response
+    pageNext = response.pages?.next?.split("pageNext=")[1]
+    index++
+
+    info(
+      `Get scheduledActions - page: ${index} - processed items: ${result.length}`
+    )
+  } while (pageNext !== undefined)
+
+  return result
+}
+
+export async function createScheduledActionsForEnvironment(
+  options: ContentfulPartialOptions,
+  scheduledActionProps: CreateUpdateScheduledActionProps[],
+  rateLimit: number
+) {
+  const { spaceId } = options
+
+  const results = []
+
+  // Chunk the request because there is a rate limit
+  // Content Management API (CMA) calls - 10 - Calls per second
+  // https://www.contentful.com/developers/docs/technical-limits/#enterprise-tier
+  // only use half of the rate limit so the service is still available for other requests
+  const chunkSize = Math.floor(rateLimit / 2) || 1
+  const chunks = chunk(scheduledActionProps, chunkSize)
+
+  for (let i = 0; i < chunks.length; i++) {
+    const promises = chunks[i].map(scheduledAction =>
+      getClient(options).scheduledActions.create({ spaceId }, scheduledAction)
+    )
+
+    const result = await promiseAllSettled(promises)
+    results.push(result)
+
+    info(
+      `Create scheduledActions - chunk: ${i + 1} from ${
+        chunks.length
+      } - processed items: ${i * chunkSize + promises.length}`
+    )
+
+    // wait a second to comply to the rate limit before processing next chunk
+    await delay(1000)
+  }
+
+  const result = results.reduce(
+    (acc, value) => {
+      acc.settled.push(...value.settled)
+      acc.values.push(...value.values)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      acc.reasons.push(...value.reasons)
+
+      return acc
+    },
+    {
+      settled: [],
+      values: [],
+      reasons: [],
+    }
+  )
+
+  return result
+}
+
+export async function deleteScheduledActionsForEnvironment(
+  options: ContentfulPartialOptions,
+  scheduledActionIds: string[],
+  rateLimit: number
+) {
+  const { spaceId, environmentId } = options
+  const results = []
+
+  // Chunk the request because there is a rate limit
+  // Content Management API (CMA) calls - 10 - Calls per second
+  // https://www.contentful.com/developers/docs/technical-limits/#enterprise-tier
+  const chunkSize = Math.floor(rateLimit / 2) || 1
+  const chunks = chunk(scheduledActionIds, chunkSize)
+
+  for (let i = 0; i < chunks.length; i++) {
+    const promises = chunks[i].map(scheduledActionId =>
+      getClient(options).scheduledActions.delete({
+        spaceId,
+        environmentId,
+        scheduledActionId,
+      })
+    )
+
+    const result = await promiseAllSettled(promises)
+    results.push(result)
+
+    info(
+      `Remove scheduledActions - chunk: ${i + 1} from ${
+        chunks.length
+      } - processed items: ${i * chunkSize + promises.length}`
+    )
+
+    // wait a second to comply to the rate limit before processing next chunk
+    await delay(1000)
+  }
+
+  const result = results.reduce(
+    (acc, value) => {
+      acc.settled.push(...value.settled)
+      acc.values.push(...value.values)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      acc.reasons.push(...value.reasons)
+
+      return acc
+    },
+    {
+      settled: [],
+      values: [],
+      reasons: [],
+    }
+  )
+
+  return result
+}
+
+export async function copyScheduledActionsBetweenReleases(
+  options: ContentfulPartialOptions,
+  source: string,
+  target: string,
+  rateLimit: number
+) {
+  const scheduledActions = await getScheduledActionsFromEnvironment(
+    options,
+    source
+  )
+
+  const scheduledActionProps = scheduledActions.map(scheduledAction => {
+    return {
+      action: scheduledAction.action,
+      entity: scheduledAction.entity,
+      environment: {
+        sys: {
+          id: target,
+          linkType: "Environment",
+          type: "Link",
+        },
+      },
+      scheduledFor: scheduledAction.scheduledFor,
+    } as CreateUpdateScheduledActionProps
+  })
+
+  const { reasons } = await createScheduledActionsForEnvironment(
+    options,
+    scheduledActionProps,
+    rateLimit
+  )
+
+  if (reasons.length) {
+    warn(
+      `Some scheduled actions could not be created: ${JSON.stringify(
+        reasons,
+        null,
+        2
+      )}`
+    )
+  }
+}
+
+function isPromiseRejectedResult(
+  promiseResult: PromiseFulfilledResult<any> | PromiseRejectedResult
+): promiseResult is PromiseRejectedResult {
+  return (promiseResult as PromiseRejectedResult).status === "rejected"
+}
+
+async function promiseAllSettled<T = unknown>(promises: Array<Promise<T>>) {
+  const settled = await Promise.allSettled(promises)
+
+  const values = settled.map(result =>
+    isPromiseRejectedResult(result) ? undefined : result.value
+  )
+
+  const reasons = settled
+    .map((result: PromiseFulfilledResult<T> | PromiseRejectedResult) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return isPromiseRejectedResult(result)
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          result.reason.stack || result.reason
+        : undefined
+    })
+    .filter(Boolean)
+
+  return {
+    settled,
+    values,
+    reasons,
+  }
+}
+
+function delay(milliseconds: number) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript-transform-paths": "^3.0.0"
   },
   "dependencies": {
-    "chalk": "^5.0.0",
+    "chalk": "4.1.2",
     "change-case": "^4.1.2",
     "contentful-management": "^7.14.0",
     "contentful-migration": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2056,11 +2056,6 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
-
 change-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"


### PR DESCRIPTION
### Summary
This PR adds the feature to copy scheduled actions from the previous release environment to the new release environment during a realease initiated by the release cli command.

This feature is needed since contentful doesn't copy the scheduled actions if you create a new environment from an existing one.

### Details
This feature will be enabled by default for the release cli command and can be explicitly opt-outed by setting the parameter `copy-scheduled-actions` to false.

### How to test

1. You need a contentful environment with some entries which contain scheduled actions
2. You can either create a new migration or call the release command with the parameter `i` set to true to ignore the pending migration check.
3. After the release is done you can check the logs if the scheduled actions got processed
4. You also need to check in contentful in the new environment if the scheduled actions got copied from the previous release environment.