### PR TITLE
feat!: migrate from sequence number to timestamp

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       time: "08:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "chalk"

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ After initializing your contentful environment, it's time to write some migratio
 npx cf-migrations create create-foo --migrationsDir src/migrations
 ```
 
-It will create a typescript migration file, `src/migrations/0001-create-foo.ts` for example. Use the flag `--useJavascript` or `--js` to create a javascript file instead.
+It will create a typescript migration file, `src/migrations/1660225580514-create-foo.ts` for example. Use the flag `--useJavascript` or `--js` to create a javascript file instead.
 
-Note that the migrations should have a proper sequence number.
+Note that the migrations should have a proper timestamp.
 
 ### 🚚 Deploy migration
 
@@ -88,13 +88,13 @@ Suppose you have the following project where there is a typescript compilation t
 │   ├── tsconfig.json
 │   ├── src/
 │       ├── migrations/
-│           ├── 0001-create-contenty-type.ts
-│           ├── 0002-add-field.ts
+│           ├── 1660225580514-create-contenty-type.ts
+│           ├── 1660225721863-add-field.ts
             ...
 │   ├── dist/
 │       ├── migrations/
-│           ├── 0001-create-contenty-type.js
-│           ├── 0002-add-field.js
+│           ├── 1660225580514-create-contenty-type.js
+│           ├── 1660225721863-add-field.js
             ...
 ...
 ```

--- a/docs/generated/CHANGELOG.md
+++ b/docs/generated/CHANGELOG.md
@@ -1,20 +1,17 @@
 # [2.0.0](https://github.com/foobaragency/cf-migrations/compare/v1.2.4...v2.0.0) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **package-update:** downgrade chalk ([7414359](https://github.com/foobaragency/cf-migrations/commit/741435908c5a431c5e2c7319564106eca338b98b))
-* patch yarn-lock after package update ([563e629](https://github.com/foobaragency/cf-migrations/commit/563e629654c40af8fd68e5ea69bfe76bfaa5462d))
-
+- **package-update:** downgrade chalk ([7414359](https://github.com/foobaragency/cf-migrations/commit/741435908c5a431c5e2c7319564106eca338b98b))
+- patch yarn-lock after package update ([563e629](https://github.com/foobaragency/cf-migrations/commit/563e629654c40af8fd68e5ea69bfe76bfaa5462d))
 
 ### Features
 
-* **copy-scheduled-actions:** copy scheduledActions from previous release ([8dc531a](https://github.com/foobaragency/cf-migrations/commit/8dc531a3fcfb014b7ea237e6c94a6864100eb33d))
-
+- **copy-scheduled-actions:** copy scheduledActions from previous release ([8dc531a](https://github.com/foobaragency/cf-migrations/commit/8dc531a3fcfb014b7ea237e6c94a6864100eb33d))
 
 ### BREAKING CHANGES
 
-* **copy-scheduled-actions:** `copyScheduledActions` and `rateLimit` are used for the scheduledActions feature.
+- **copy-scheduled-actions:** `copyScheduledActions` and `rateLimit` are used for the scheduledActions feature.
 
 ## [1.2.4](https://github.com/foobaragency/cf-migrations/compare/v1.2.3...v1.2.4) (2021-12-14)
 

--- a/lib/cli/commands/deploy.ts
+++ b/lib/cli/commands/deploy.ts
@@ -45,7 +45,6 @@ export const handler = async (args: DeployArgs) => {
   })
 }
 
-// TODO this verification should be executed when deploying as well
 async function assureEnvironmentIsInitialized(
   options: ContentfulPartialOptions
 ) {

--- a/lib/contentful/management.ts
+++ b/lib/contentful/management.ts
@@ -4,7 +4,7 @@ import { config } from "../config"
 import { ContentfulPartialOptions } from "../types"
 
 import {
-  createMigrationEntries,
+  createMigrationEntry,
   getContentTypes,
   getMigrationEntries,
 } from "./migrationEntries"
@@ -15,7 +15,7 @@ export async function updateMigrationState(
   migrationStates: MigrationEntry[]
 ) {
   for (const stateFields of migrationStates) {
-    await createMigrationEntries(stateFields, options)
+    await createMigrationEntry(stateFields, options)
   }
 }
 

--- a/lib/contentful/migrationEntries.ts
+++ b/lib/contentful/migrationEntries.ts
@@ -6,7 +6,7 @@ import { ContentfulPartialOptions } from "../types"
 import { getClient } from "./client"
 import { MigrationEntry } from "./types"
 
-export async function createMigrationEntries(
+export async function createMigrationEntry(
   fields: MigrationEntry,
   options: ContentfulPartialOptions
 ) {

--- a/lib/errorMessages.ts
+++ b/lib/errorMessages.ts
@@ -2,10 +2,8 @@ export const errorMessages = {
   migration: {
     invalidNameFormat: (file: string) =>
       `Invalid migration name format: ${file}. Unable to determine the migration sequence.`,
-    sequenceGap: (file: string) =>
-      `There's a migration gap before the file ${file}. Missing migration files.`,
-    duplicatedSequence: (file: string) =>
-      `Duplicated migration sequence: ${file}. Unable to determine the migration sequence.`,
+    duplicatedTimestamp: (file: string) =>
+      `Duplicated migration timestamps: ${file}. Unable to determine the migration sequence.`,
   },
   cli: {
     argument: (option: string, env: string) =>

--- a/lib/migrationManagement/migrationFiles.ts
+++ b/lib/migrationManagement/migrationFiles.ts
@@ -2,7 +2,6 @@ import path from "path"
 
 import { paramCase } from "change-case"
 import fg from "fast-glob"
-import last from "lodash/last"
 
 import { getMigrationDetailsAndValidate } from "./migrationValidations"
 import { jsMigrationTemplate, tsMigrationTemplate } from "./fileTemplates"
@@ -29,14 +28,10 @@ export function getNextMigrationFileName(
   name: string,
   migrationFileNames: string[]
 ) {
-  const lastValidMigration = last(
-    getMigrationDetailsAndValidate(migrationFileNames)
-  )
-  const lastSequence = lastValidMigration?.sequence
-  const sequence = lastSequence ? lastSequence + 1 : 1
-  const sequenceString = String(sequence).padStart(4, "0")
+  getMigrationDetailsAndValidate(migrationFileNames)
+  const timestamp = new Date().getTime()
 
-  return `${sequenceString}-${paramCase(name)}`
+  return `${timestamp}-${paramCase(name)}`
 }
 
 export function getMigrationFileData(

--- a/lib/migrationManagement/migrationValidations.ts
+++ b/lib/migrationManagement/migrationValidations.ts
@@ -1,12 +1,12 @@
 import { errorMessages } from "../errorMessages"
 
 type MigrationDetails = {
-  sequence: number
+  timestamp: number
   fileName: string
 }
 
 /**
- * Get migrations sequences and file names while validating them. The names should be sorted.
+ * Get migrations timestamp and file names while validating them. The names should be sorted.
  */
 export function getMigrationDetailsAndValidate(migrationFileNames: string[]) {
   const migrationsDetails = getMigrationsDetails(migrationFileNames)
@@ -15,11 +15,8 @@ export function getMigrationDetailsAndValidate(migrationFileNames: string[]) {
   filterInvalidNameFormat(migrationsDetails).forEach(({ fileName }) =>
     messages.push(errorMessages.migration.invalidNameFormat(fileName))
   )
-  filterSequenceGap(migrationsDetails).forEach(({ fileName }) =>
-    messages.push(errorMessages.migration.sequenceGap(fileName))
-  )
-  filterDuplicatedSequence(migrationsDetails).forEach(({ fileName }) =>
-    messages.push(errorMessages.migration.duplicatedSequence(fileName))
+  filterDuplicatedTimestamp(migrationsDetails).forEach(({ fileName }) =>
+    messages.push(errorMessages.migration.duplicatedTimestamp(fileName))
   )
 
   if (messages.length > 0) {
@@ -30,34 +27,24 @@ export function getMigrationDetailsAndValidate(migrationFileNames: string[]) {
 }
 
 function getMigrationsDetails(migrationFileNames: string[]) {
-  return migrationFileNames.map((name, index) => ({
-    fileName: migrationFileNames[index],
-    sequence: Number(name.split("-")[0]),
+  return migrationFileNames.map(name => ({
+    fileName: name,
+    timestamp: Number(name.split("-")[0]),
   }))
 }
 
 function filterInvalidNameFormat(migrationsInfo: MigrationDetails[]) {
-  return migrationsInfo.filter(({ sequence: value }) => isNaN(value))
+  return migrationsInfo.filter(({ timestamp: value }) => isNaN(value))
 }
 
-function filterSequenceGap(migrationsInfo: MigrationDetails[]) {
-  return migrationsInfo.filter((info, index) => {
-    if (index === 0) {
-      return false
-    }
+function filterDuplicatedTimestamp(migrationsInfo: MigrationDetails[]) {
+  const existingTimestamps: number[] = []
 
-    return info.sequence - migrationsInfo[index - 1].sequence > 1
-  })
-}
-
-function filterDuplicatedSequence(migrationsInfo: MigrationDetails[]) {
-  const existingSequences: number[] = []
-
-  return migrationsInfo.filter(({ sequence: value }) => {
-    if (existingSequences.includes(value)) {
+  return migrationsInfo.filter(({ timestamp: value }) => {
+    if (existingTimestamps.includes(value)) {
       return true
     }
 
-    existingSequences.push(value)
+    existingTimestamps.push(value)
   })
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript-transform-paths": "^3.0.0"
   },
   "dependencies": {
-    "chalk": "5.0.1",
+    "chalk": "4.1.2",
     "change-case": "^4.1.2",
     "contentful-management": "^10.0.0",
     "contentful-migration": "^4.5.0",

--- a/test/migrationManagement/__snapshots__/migrationFiles.test.ts.snap
+++ b/test/migrationManagement/__snapshots__/migrationFiles.test.ts.snap
@@ -19,3 +19,43 @@ export = up
 
 "
 `;
+
+exports[`Migration Files when getting migration file data with sequence number when creating a javascript migration file returns the expected data 1`] = `
+"module.exports = function (migration) {
+  // Write your migration here
+}
+
+"
+`;
+
+exports[`Migration Files when getting migration file data with sequence number when creating a typescript migration file returns the expected data 1`] = `
+"import { MigrationFunction } from \\"contentful-migration\\"
+
+const up: MigrationFunction = (migration, context) => {
+  // Write your migration here
+}
+
+export = up
+
+"
+`;
+
+exports[`Migration Files when getting migration file data with timestamp when creating a javascript migration file returns the expected data 1`] = `
+"module.exports = function (migration) {
+  // Write your migration here
+}
+
+"
+`;
+
+exports[`Migration Files when getting migration file data with timestamp when creating a typescript migration file returns the expected data 1`] = `
+"import { MigrationFunction } from \\"contentful-migration\\"
+
+const up: MigrationFunction = (migration, context) => {
+  // Write your migration here
+}
+
+export = up
+
+"
+`;

--- a/test/migrationManagement/__snapshots__/migrationState.test.ts.snap
+++ b/test/migrationManagement/__snapshots__/migrationState.test.ts.snap
@@ -9,12 +9,27 @@ Array [
   },
   Object {
     "fileName": Object {
+      "en-US": "1660226256621-migration",
+    },
+  },
+  Object {
+    "fileName": Object {
       "en-US": "0002-migration",
     },
   },
   Object {
     "fileName": Object {
       "en-US": "0004-migration",
+    },
+  },
+  Object {
+    "fileName": Object {
+      "en-US": "1660226254499-migration",
+    },
+  },
+  Object {
+    "fileName": Object {
+      "en-US": "1660226255228-migration",
     },
   },
 ]

--- a/test/migrationManagement/migrationFiles.test.ts
+++ b/test/migrationManagement/migrationFiles.test.ts
@@ -1,14 +1,22 @@
+import { basename } from "path"
+
 import {
   getMigrationFileData,
   getNextMigrationFileName,
   processMigrationFileNames,
 } from "../../lib/migrationManagement/migrationFiles"
 import { config } from "../config"
-import { basename } from "path"
 
 describe("Migration Files", () => {
   it("assure migration files are sorted accordingly to the migration numbers", async () => {
-    const migrations = ["0002-migration", "0001-migration", "0003-migration"]
+    const migrations = [
+      "0002-migration",
+      "1660226256621-migration",
+      "0001-migration",
+      "1660226254499-migration",
+      "0003-migration",
+      "1660226255228-migration",
+    ]
     const processedMigrations = await processMigrationFileNames(
       config.migrationsDirectory,
       migrations
@@ -17,18 +25,27 @@ describe("Migration Files", () => {
     expect(processedMigrations[0]).toEqual("0001-migration")
     expect(processedMigrations[1]).toEqual("0002-migration")
     expect(processedMigrations[2]).toEqual("0003-migration")
+    expect(processedMigrations[3]).toEqual("1660226254499-migration")
+    expect(processedMigrations[4]).toEqual("1660226255228-migration")
+    expect(processedMigrations[5]).toEqual("1660226256621-migration")
   })
 
   describe("when getting the next migration file name", () => {
     describe("when there are migration files", () => {
-      const migrationFileNames = ["0001-migration", "0002-migration"]
+      const migrationFileNames = [
+        "0001-migration",
+        "0002-migration",
+        "1660226254499-migration",
+      ]
       const nextMigrationFileName = getNextMigrationFileName(
         "migration",
         migrationFileNames
       )
 
-      it("increases the sequence by one", () => {
-        expect(nextMigrationFileName).toEqual("0003-migration")
+      it("number should be higher than the last one", () => {
+        expect(Number(nextMigrationFileName.split("-")[0])).toBeGreaterThan(
+          Number("1660226254499-migration".split("-")[0])
+        )
       })
     })
 
@@ -36,12 +53,16 @@ describe("Migration Files", () => {
       const nextMigrationFileName = getNextMigrationFileName("migration", [])
 
       it("starts the sequence in one", () => {
-        expect(nextMigrationFileName).toEqual("0001-migration")
+        expect(nextMigrationFileName).not.toBeNull()
       })
     })
 
     describe("when there are migrations with invalid sequence", () => {
-      const migrationFileNames = ["0001-migration", "invalid-migration"]
+      const migrationFileNames = [
+        "0001-migration",
+        "1660226254499-migration",
+        "invalid-migration",
+      ]
 
       it("throws an error", () => {
         expect(() =>
@@ -51,7 +72,7 @@ describe("Migration Files", () => {
     })
   })
 
-  describe("when getting migration file data", () => {
+  describe("when getting migration file data with sequence number", () => {
     const migrationsDir = "migrations"
     const migrationFileName = "0001-migration"
 
@@ -82,6 +103,45 @@ describe("Migration Files", () => {
 
         expect(migrationData.content).toMatchSnapshot()
         expect(basename(migrationData.path)).toEqual("0001-migration.ts")
+      })
+    })
+  })
+
+  describe("when getting migration file data with timestamp", () => {
+    const migrationsDir = "migrations"
+    const migrationFileName = "1660226254499-migration"
+
+    describe("when creating a javascript migration file", () => {
+      const useJavascript = true
+
+      it("returns the expected data", () => {
+        const migrationData = getMigrationFileData(
+          migrationsDir,
+          migrationFileName,
+          useJavascript
+        )
+
+        expect(migrationData.content).toMatchSnapshot()
+        expect(basename(migrationData.path)).toEqual(
+          "1660226254499-migration.js"
+        )
+      })
+    })
+
+    describe("when creating a typescript migration file", () => {
+      const useJavascript = false
+
+      it("returns the expected data", () => {
+        const migrationData = getMigrationFileData(
+          migrationsDir,
+          migrationFileName,
+          useJavascript
+        )
+
+        expect(migrationData.content).toMatchSnapshot()
+        expect(basename(migrationData.path)).toEqual(
+          "1660226254499-migration.ts"
+        )
       })
     })
   })

--- a/test/migrationManagement/migrationState.test.ts
+++ b/test/migrationManagement/migrationState.test.ts
@@ -8,15 +8,21 @@ describe("Migration State", () => {
   it("generates a valid migration state update based on the pending migrations", () => {
     const pendingMigrations = [
       "0001-migration",
+      "1660226256621-migration",
       "0002-migration",
       "0003-migration",
       "0004-migration",
+      "1660226254499-migration",
+      "1660226255228-migration",
     ]
     const runMigrationsResult = [
       { successful: true, fileName: pendingMigrations[0] },
       { successful: true, fileName: pendingMigrations[1] },
-      { successful: false, fileName: pendingMigrations[2] },
-      { successful: true, fileName: pendingMigrations[3] },
+      { successful: true, fileName: pendingMigrations[2] },
+      { successful: false, fileName: pendingMigrations[3] },
+      { successful: true, fileName: pendingMigrations[4] },
+      { successful: true, fileName: pendingMigrations[5] },
+      { successful: true, fileName: pendingMigrations[6] },
     ]
     const migrationStateUpdatePayload = generateMigrationStates(
       pendingMigrations,
@@ -27,8 +33,17 @@ describe("Migration State", () => {
   })
 
   it("filters the pending migrations", () => {
-    const deployedMigrations = ["0001-migration", "0002-migration"]
-    const migrationFileNames = [...deployedMigrations, "0003-migration"]
+    const deployedMigrations = [
+      "0001-migration",
+      "0002-migration",
+      "1660226256621-migration",
+    ]
+    const migrationFileNames = [
+      ...deployedMigrations,
+      "0003-migration",
+      "1660226254499-migration",
+      "1660226255228-migration",
+    ]
 
     const pendingMigrations = getPendingMigrations(
       config.migrationsDirectory,
@@ -38,6 +53,8 @@ describe("Migration State", () => {
 
     expect(pendingMigrations.map(({ fileName }) => fileName)).toEqual([
       "0003-migration",
+      "1660226254499-migration",
+      "1660226255228-migration",
     ])
   })
 })

--- a/test/migrationManagement/migrationValidations.test.ts
+++ b/test/migrationManagement/migrationValidations.test.ts
@@ -3,7 +3,14 @@ import { getMigrationDetailsAndValidate } from "../../lib/migrationManagement/mi
 
 describe("Migration Validation", () => {
   describe("when all the migration names are correct", () => {
-    const migrations = ["0001-migration", "0002-migration", "0003-migration"]
+    const migrations = [
+      "0001-migration",
+      "0002-migration",
+      "0003-migration",
+      "1660226254499-migration",
+      "1660226255228-migration",
+      "1660226256621-migration",
+    ]
 
     it("throws no error", () => {
       expect(() =>
@@ -16,8 +23,11 @@ describe("Migration Validation", () => {
     it("throws an invalid name error", () => {
       const migrations = [
         "0001-migration",
+        "1660226254499-migration",
         "invalid-migration",
         "0003-migration",
+        "1660226255228-migration",
+        "1660226256621-migration",
       ]
 
       expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
@@ -28,9 +38,12 @@ describe("Migration Validation", () => {
     describe("when multiple migrations have invalid names", () => {
       it("also throws an invalid name error", () => {
         const migrations = [
+          "1660226255228-migration",
+          "1660226256621-migration",
           "invalid-migration",
           "another-invalid-migration",
           "0003-migration",
+          "1660226254499-migration",
         ]
 
         expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
@@ -39,39 +52,6 @@ describe("Migration Validation", () => {
             errorMessages.migration.invalidNameFormat(
               "another-invalid-migration"
             ),
-          ].join("\n")
-        )
-      })
-    })
-  })
-
-  describe("when there're migration gaps", () => {
-    it("thows an error", () => {
-      const migrations = ["0001-migration", "0003-migration"]
-
-      expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
-        errorMessages.migration.sequenceGap("0003-migration")
-      )
-    })
-
-    describe("when there're consecutive missing migration files", () => {
-      const migrations = ["0001-migration", "0004-migration"]
-
-      it("throws an error showing the migration next to the gap", () => {
-        expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
-          errorMessages.migration.sequenceGap("0004-migration")
-        )
-      })
-    })
-
-    describe("when there're multiple gaps", () => {
-      const migrations = ["0001-migration", "0003-migration", "0005-migration"]
-
-      it("throws an error listing the migration files next to the gaps", () => {
-        expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
-          [
-            errorMessages.migration.sequenceGap("0003-migration"),
-            errorMessages.migration.sequenceGap("0005-migration"),
           ].join("\n")
         )
       })
@@ -87,8 +67,24 @@ describe("Migration Validation", () => {
 
     it("throws an error showing the duplicated migration sequence", () => {
       expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
-        errorMessages.migration.duplicatedSequence(
+        errorMessages.migration.duplicatedTimestamp(
           "0003-duplicated-migration-sequence"
+        )
+      )
+    })
+  })
+
+  describe("when there're duplicated migration timestamps", () => {
+    const migrations = [
+      "1660226254499-migration",
+      "1660226255228-migration",
+      "1660226255228-duplicated-migration-timestamp",
+    ]
+
+    it("throws an error showing the duplicated migration timestamp", () => {
+      expect(() => getMigrationDetailsAndValidate(migrations)).toThrowError(
+        errorMessages.migration.duplicatedTimestamp(
+          "1660226255228-duplicated-migration-timestamp"
         )
       )
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,10 +2328,13 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
-chalk@5.0.1, chalk@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
-  integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2342,13 +2345,10 @@ chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
+chalk@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
+  integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
 
 change-case@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
## Why migrating from sequence numbers to timestamps?
With the current migration sequence number there is a huge flaw for projects with multiple devs who can write migrations.

### How is it working right now?
The current implementation checks for gaps in the sequence and for duplicated migration numbers if one the cases happen it will throw an error and will not run the migrations. At the same time it generates new migrations with the nex sequence number based on the migrations that already exists in the migrations folder.

### What is the issue with the current implementation?
The issue could already happen with only two devs, for example we have an existing project with 0001..0003 existing migrtations. The first dev is working on a new content type  `type  a` and its `subtype` he creates two migrations the first one for the `subtype` and the second for the `type a`, he will get those migration files:
- 0004-create-sub-type-for-type-a.ts
- 0005-create-type-a.ts
In the mean time the second dev is also working on a migration to create `type b` and will get this migration file:
- 0004-create-type-b.ts
If either the first or the second dev is merging the changes to the main branch the other one will get an error since the migration number is not unique anymore and the dev who didn't merge first will have to update the sequence number manually. If there are more devs than two it will only get worse.

### What is the proposed solution to the problem?
To prevent this kind of issue, timestamps should be used instead of sequence numbers. With timestamps an order for importing migrations will still be inplace and it is unlikely that two devs get the same timestamp since they are in milliseconds. For the rare case of duplicate timestamps the check will still be there and the dev has to change the migration manually or generate a new one like before but as already mentioned this case should be unlikely and rare.

### Will there be problems for existing migrations with sequence numbers after changing to timestamps?
The migration from sequence numbers to timestamp shouldn't be a problem and should work with existing migrations that still use sequence numbers since the tool is checking the numbers/timestamps and is sorting them ascending to create an order for importing the migrations.

#### What has changed?
- migrate from sequence number to timestamp
- adjusting and adding new tests after migrating from sequence number to timestamp
- rename function createMigrationEntries to createMigrationEntry since it was misleading

⚠️ I marked this change as a breaking change even if it will not break anything for the tool itself with the old sequence numbers, however it could be that it breaks existing tests in projects if sequence numbers in the old format are expected.