### PR TITLE
ci: changed semantic-release preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,18 @@
       "master"
     ],
     "plugins": [
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
       [
         "@semantic-release/changelog",
         {

--- a/test/migrationManagement/__snapshots__/migrationFiles.test.ts.snap
+++ b/test/migrationManagement/__snapshots__/migrationFiles.test.ts.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Migration Files when getting migration file data when creating a javascript migration file returns the expected data 1`] = `
-"module.exports = function (migration) {
-  // Write your migration here
-}
-
-"
-`;
-
-exports[`Migration Files when getting migration file data when creating a typescript migration file returns the expected data 1`] = `
-"import { MigrationFunction } from \\"contentful-migration\\"
-
-const up: MigrationFunction = (migration, context) => {
-  // Write your migration here
-}
-
-export = up
-
-"
-`;
-
 exports[`Migration Files when getting migration file data with sequence number when creating a javascript migration file returns the expected data 1`] = `
 "module.exports = function (migration) {
   // Write your migration here


### PR DESCRIPTION
As described in a [previous PR](https://github.com/foobaragency/cf-migrations/pull/513#issue-1338654975), `semantic-release` is configured by default to use [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format). Instead, the team would like to use features from [conventional commits](https://www.conventionalcommits.org/) (e.g. [using bangs to indicate breaking changes](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with--to-draw-attention-to-breaking-change)).

To do so, in this PR, we [change the `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` preset as described in the documentation](https://semantic-release.gitbook.io/semantic-release/#commit-message-format).

This allows us to successfully use features from conventional commits as shown in the image of a dry run below:
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/102958266/186359757-ebfc7c58-f787-4908-860e-5186f4ff57db.png">
